### PR TITLE
Better support for app.config transforms

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -5,7 +5,7 @@ ECHO.
 ECHO Building Primary Nuget Package BuildOnce
 ECHO =======================================
 
-nuget pack src\BuildOnce\BuildOnce.csproj -build -Prop Configuration=Release -IncludeReferencedProjects -OutputDirectory artifacts
+nuget pack src\BuildOnce\BuildOnce.csproj -build -Prop Configuration=Release -IncludeReferencedProjects -OutputDirectory artifacts -Tool
 
 ECHO.
 ECHO All done

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Make sure you save the changes to your project file! When VS restarts it will de
 If they are out of sync you will receive an error telling you to correct the issue.
 
 ## Version
-* BuildOnce 0.2.0
+* BuildOnce 0.3.0
 
 ## License
 MIT

--- a/src/BuildOnce/BuildOnce.nuspec
+++ b/src/BuildOnce/BuildOnce.nuspec
@@ -16,7 +16,7 @@
     <tags>CI CD Config Transform</tags>
   </metadata>
   <files>
-    <file src="bin/Release/Microsoft.Web.XmlTransform.dll" target="lib/net45" />
+    <file src="bin/Release/Microsoft.Web.XmlTransform.dll" target="tools" />
     <file src="msbuild/BuildOnce.props" target="build" />
     <file src="msbuild/BuildOnce.targets" target="build" />
   </files>

--- a/src/BuildOnce/Properties/AssemblyInfo.cs
+++ b/src/BuildOnce/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyVersion("0.3.0.0")]
+[assembly: AssemblyFileVersion("0.3.0.0")]

--- a/src/BuildOnce/TransformConfigTask.cs
+++ b/src/BuildOnce/TransformConfigTask.cs
@@ -13,6 +13,10 @@ namespace BuildOnce
         public ITaskItem[] Transforms { get; set; }
         [Required]
         public string OutputPath { get; set; }
+        [Required]
+        public string AssemblyName { get; set; }
+        [Required]
+        public string OutputType { get; set; }
 
         public Tree<ITaskItem> Tree { get; set; }
 
@@ -42,6 +46,9 @@ namespace BuildOnce
 
                     var dependency = SourceList
                         .Where(c => c.ItemSpec.Equals(dependentMeta, StringComparison.OrdinalIgnoreCase))
+                        .FirstOrDefault() ??
+                        Transforms
+                        .Where(c => c.ItemSpec.Equals(dependentMeta, StringComparison.OrdinalIgnoreCase))
                         .FirstOrDefault();
 
                     if (dependency == null)
@@ -62,6 +69,11 @@ namespace BuildOnce
                 }
             });
 
+            if (!isSuccesful)
+            {
+                return false;
+            }
+
             Log.LogMessage(Tree.ToString(0));
 
             var xmlTransformer = new XmlTransfomer();
@@ -72,7 +84,7 @@ namespace BuildOnce
                     item.Key.GetMetadata("Extension").Equals(".xml", StringComparison.OrdinalIgnoreCase) ||
                     item.Key.GetMetadata("Extension").Equals(".csdef", StringComparison.OrdinalIgnoreCase))
                 {
-                    xmlTransformer.Transform(item, OutputPath);
+                    xmlTransformer.Transform(item, OutputPath, AssemblyName, OutputType);
                 }
                 else
                 {

--- a/src/BuildOnce/XmlTransformer.cs
+++ b/src/BuildOnce/XmlTransformer.cs
@@ -2,7 +2,6 @@
 using Microsoft.Web.XmlTransform;
 using System;
 using System.IO;
-using System.Linq;
 
 namespace BuildOnce
 {
@@ -11,7 +10,7 @@ namespace BuildOnce
         /// <summary>
         /// Executes transforms for all configuration detected
         /// </summary>
-        public void Transform(Tree<ITaskItem> tree, string outputPath)
+        public void Transform(Tree<ITaskItem> tree, string outputPath, string assemblyName, string outputType)
         {
             foreach (var branch in tree)
             {
@@ -19,40 +18,19 @@ namespace BuildOnce
 
                 var sourcePath = tree.Key.GetMetadata("FullPath");
                 var transformPath = branch.Key.GetMetadata("FullPath");
+
+                var isAppConfig = string.Format("{0}{1}", 
+                    tree.Key.GetMetadata("Filename"), 
+                    tree.Key.GetMetadata("Extension")).Equals("app.config", StringComparison.OrdinalIgnoreCase);
+
+                var assemblyExtenion = outputType.Equals("Library", StringComparison.OrdinalIgnoreCase) ? ".dll" :
+                    ".exe";
+
                 var destinationPath = string.Format("{0}//{1}//{2}{3}{4}",
                     outputPath,
                     targetTransform,
                     tree.Key.GetMetadata("RelativeDir"),
-                    tree.Key.GetMetadata("Filename"),
-                    tree.Key.GetMetadata("Extension"));
-
-                TransformXML(sourcePath, transformPath, destinationPath);
-            }
-        }
-
-        /// <summary>
-        /// Executes transforms for a single configuration
-        /// </summary>
-        public void Transform(Tree<ITaskItem> tree, string outputPath, string targetConfiguration)
-        {
-            var target = string.Format("{0}{1}.{2}{3}",
-                    tree.Key.GetMetadata("RelativeDir"),
-                    tree.Key.GetMetadata("Filename"),
-                    targetConfiguration,
-                    tree.Key.GetMetadata("Extension"));
-
-
-            var transformItem = tree.Where(k => k.Key.ItemSpec.Equals(target, StringComparison.OrdinalIgnoreCase))
-                .FirstOrDefault();
-
-            if (transformItem != null)
-            {
-                var sourcePath = tree.Key.GetMetadata("FullPath");
-                var transformPath = transformItem.Key.GetMetadata("FullPath");
-                var destinationPath = string.Format("{0}{1}{2}{3}",
-                    outputPath,
-                    tree.Key.GetMetadata("RelativeDir"),
-                    tree.Key.GetMetadata("Filename"),
+                    isAppConfig ? assemblyName + assemblyExtenion : tree.Key.GetMetadata("Filename"),
                     tree.Key.GetMetadata("Extension"));
 
                 TransformXML(sourcePath, transformPath, destinationPath);

--- a/src/BuildOnce/msbuild/BuildOnce.targets
+++ b/src/BuildOnce/msbuild/BuildOnce.targets
@@ -23,7 +23,7 @@
   <UsingTask TaskName="TransformConfigTask" AssemblyFile="@(BuildOnceLibrary->'%(FullPath)')" Condition="'@(BuildOnceLibrary->Count())' == '1'" />
   
   <Target Name="TransformConfig" AfterTargets="AfterBuild" Condition="'$(DeployOnceEnabled)' == 'True' And '@(BuildOnceLibrary->Count())' == '1'" DependsOnTargets="ValidateBuildOnceLibrary" >
-    <TransformConfigTask Sources="@(Sources)" Transforms="@(Transforms)" OutputPath="$(DeployOnceOutputPath)" />
+    <TransformConfigTask Sources="@(Sources)" Transforms="@(Transforms)" OutputPath="$(DeployOnceOutputPath)" AssemblyName="$(AssemblyName)" OutputType="$(OutputType)" />
   </Target>
   
   <Target Name="CleanTransformOutput" AfterTargets="Clean" Condition="'$(BuildOnceRemoveOutputOnClean)' == 'True'">


### PR DESCRIPTION
This change adds support for app.config transforms which will now be renamed using the build output and extension.

Also moved the nuget package content to the tools folder so that it does not get included as dependencies in the project.
